### PR TITLE
Added uniform functionality for field 'datum_eerste_tenaamstelling_in…

### DIFF
--- a/src/RDWOpenData/RDW.php
+++ b/src/RDWOpenData/RDW.php
@@ -79,11 +79,18 @@ class RDW {
 					$value = null;
 					break;
 				case 'datum_eerste_toelating':
+				case 'datum_eerste_tenaamstelling_in_nederland':
 				case 'datum_eerste_afgifte_nederland':
 				case 'datum_tenaamstelling':
 				case 'vervaldatum_apk':
 				case 'vervaldatum_tachograaf':
-					$value = DateTime::createFromFormat('Ymd', $value);
+					$dt_key = $key . '_dt';
+					if(isset($output[$dt_key])) {
+						$value = DateTime::createFromFormat('Y-m-d\TH:i:s.u', $output[$dt_key]);
+					} else {
+						$value = DateTime::createFromFormat('Ymd', $value);
+						$value->setTime(0, 0, 0, 0);
+					}
 					break;
 				case 'api_gekentekende_voertuigen_assen':
 				case 'api_gekentekende_voertuigen_brandstof':


### PR DESCRIPTION
Added uniform functionality for field 'datum_eerste_tenaamstelling_in_nederland' such that it is similarly loaded as a DateTime. Additionally, it first looks if there is a field available that contains a more specific format, if not it falls back to a slightly modified 'ymd' implementation that sets the time to zero.